### PR TITLE
removed unused usings

### DIFF
--- a/Swashbuckle.MVC/Swashbuckle.MVC.NuGet/SwashbucckleMVCController.cs
+++ b/Swashbuckle.MVC/Swashbuckle.MVC.NuGet/SwashbucckleMVCController.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Caching;
-using System.Web;
-using System.Web.Mvc;
+﻿using System.Web.Mvc;
 
 namespace ExporterWeb.Controllers
 {


### PR DESCRIPTION
Having there System.Runtime.Caching causes compilation issues with a default project as it's not a default assembly.
This is a pull request for #1 